### PR TITLE
Add History page with book citation

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,3 +20,21 @@ Our scope of work was introduced by Edsger W. Dijkstra in Meeting 0 (Oslo, Norwa
 * Guidelines of partitioning large programming tasks and defining the interfaces between the parts;
 * Software for mechanized assistance to program composition.
 
+<h2>History</h2>
+
+In December 1968, IFIP Working Group 2.1 adopted Aad van Wijngaarden's proposal as a successor to Algol 60, ultimately leading to ALGOL 68. A group of WG2.1 members opposed the proposal and produced a minority report. They also felt that rather than just programming languages, a forum was needed to discuss the general problem of programming. Another impetus was the findings of the first of the NATO Software Engineering Conferences, held in 1968, which spoke of the "software crisis" then seen as gripping the computing world.
+
+IFIP's parent committee TC2 approved the formation of a new Working Group, WG2.3, for this purpose. Mike Woodger agreed to chair it, and Brian Randell suggested the title "Programming Methodology."
+
+An organizing meeting was held in Oslo, 20--22 July 1969, with the following attending: Ole-Johan Dahl, Edsger W. Dijkstra, Douglas McIlroy, Brian Randell, Gerhard Seegmueller, Wlad Turski, Mike Woodger, and Manfred Paul (chair of WG2.1). Doug Ross was also a founding member.
+
+The first formal meeting was held in Copenhagen, Denmark in March 1970. It was attended by Ole-Johan Dahl, Edsger W. Dijkstra, Per Brinch Hansen, Tony Hoare, M. M. Lehman, J. Madey, Doug McIlroy, George Radin, Brian Randell, John Reynolds, Doug Ross, Christopher Strachey, and Warren Teitelman.
+
+The founding members were predominantly academic, and a deliberate attempt was made to bring in members from industry and commerce as well as from Asia and the USSR. WG2.3 generally meets once or twice a year for five days at a time. Until 1976, all meetings were held in Europe, but after that meetings often alternated between Europe and North America. Several meetings have been held in Australia.
+
+In its initial years, WG2.3 did not produce reports of any kind of its meetings. Meetings centered on the presentation and discussion of research underway, which meant that members could receive their colleagues' constructive criticism at a much earlier stage than usual. As such, WG2.3 became a productive assembly at which researchers such as Dijkstra could work out many of the ideas that they subsequently brought forth in published papers.
+
+In the late 1970s, it was felt that WG2.3 should make more public the nature of its work and what had been accomplished. Accordingly, the book *Programming Methodology: A Collection of Articles by Members of IFIP WG2.3* (edited by David Gries, Springer-Verlag, 1978) was published. In 2003, a second book *Programming Methodology* (edited by Annabelle McIver and Carroll Morgan, Springer-Verlag) was published, containing both new material and reviews of areas and problems for further investigation.
+
+For more on the history of WG2.3, see Mike Woodger's essay "A History of IFIP WG2.3" in the 1978 book, and the [Wikipedia article on IFIP Working Group 2.3](https://en.wikipedia.org/wiki/IFIP_Working_Group_2.3).
+

--- a/index.md
+++ b/index.md
@@ -20,21 +20,3 @@ Our scope of work was introduced by Edsger W. Dijkstra in Meeting 0 (Oslo, Norwa
 * Guidelines of partitioning large programming tasks and defining the interfaces between the parts;
 * Software for mechanized assistance to program composition.
 
-<h2>History</h2>
-
-In December 1968, IFIP Working Group 2.1 adopted Aad van Wijngaarden's proposal as a successor to Algol 60, ultimately leading to ALGOL 68. A group of WG2.1 members opposed the proposal and produced a minority report. They also felt that rather than just programming languages, a forum was needed to discuss the general problem of programming. Another impetus was the findings of the first of the NATO Software Engineering Conferences, held in 1968, which spoke of the "software crisis" then seen as gripping the computing world.
-
-IFIP's parent committee TC2 approved the formation of a new Working Group, WG2.3, for this purpose. Mike Woodger agreed to chair it, and Brian Randell suggested the title "Programming Methodology."
-
-An organizing meeting was held in Oslo, 20--22 July 1969, with the following attending: Ole-Johan Dahl, Edsger W. Dijkstra, Douglas McIlroy, Brian Randell, Gerhard Seegmueller, Wlad Turski, Mike Woodger, and Manfred Paul (chair of WG2.1). Doug Ross was also a founding member.
-
-The first formal meeting was held in Copenhagen, Denmark in March 1970. It was attended by Ole-Johan Dahl, Edsger W. Dijkstra, Per Brinch Hansen, Tony Hoare, M. M. Lehman, J. Madey, Doug McIlroy, George Radin, Brian Randell, John Reynolds, Doug Ross, Christopher Strachey, and Warren Teitelman.
-
-The founding members were predominantly academic, and a deliberate attempt was made to bring in members from industry and commerce as well as from Asia and the USSR. WG2.3 generally meets once or twice a year for five days at a time. Until 1976, all meetings were held in Europe, but after that meetings often alternated between Europe and North America. Several meetings have been held in Australia.
-
-In its initial years, WG2.3 did not produce reports of any kind of its meetings. Meetings centered on the presentation and discussion of research underway, which meant that members could receive their colleagues' constructive criticism at a much earlier stage than usual. As such, WG2.3 became a productive assembly at which researchers such as Dijkstra could work out many of the ideas that they subsequently brought forth in published papers.
-
-In the late 1970s, it was felt that WG2.3 should make more public the nature of its work and what had been accomplished. Accordingly, the book *Programming Methodology: A Collection of Articles by Members of IFIP WG2.3* (edited by David Gries, Springer-Verlag, 1978) was published. In 2003, a second book *Programming Methodology* (edited by Annabelle McIver and Carroll Morgan, Springer-Verlag) was published, containing both new material and reviews of areas and problems for further investigation.
-
-For more on the history of WG2.3, see Mike Woodger's essay "A History of IFIP WG2.3" in the 1978 book, and the [Wikipedia article on IFIP Working Group 2.3](https://en.wikipedia.org/wiki/IFIP_Working_Group_2.3).
-

--- a/pages/history.md
+++ b/pages/history.md
@@ -16,6 +16,10 @@ The founding members were predominantly academic, and a deliberate attempt was m
 
 In its initial years, WG2.3 did not produce reports of any kind of its meetings. Meetings centered on the presentation and discussion of research underway, which meant that members could receive their colleagues' constructive criticism at a much earlier stage than usual. As such, WG2.3 became a productive assembly at which researchers such as Dijkstra could work out many of the ideas that they subsequently brought forth in published papers.
 
-In the late 1970s, it was felt that WG2.3 should make more public the nature of its work and what had been accomplished. Accordingly, the book *Programming Methodology: A Collection of Articles by Members of IFIP WG2.3* (edited by David Gries, Springer-Verlag, 1978) was published. In 2003, a second book *Programming Methodology* (edited by Annabelle McIver and Carroll Morgan, Springer-Verlag) was published, containing both new material and reviews of areas and problems for further investigation.
+In the late 1970s, it was felt that WG2.3 should make more public the nature of its work and what had been accomplished. Accordingly, the book *Programming Methodology* [[1]](#ref1) was published. In 2003, a second book *Programming Methodology* (edited by Annabelle McIver and Carroll Morgan, Springer-Verlag) was published, containing both new material and reviews of areas and problems for further investigation.
 
-For more on the history of WG2.3, see Mike Woodger's essay "A History of IFIP WG2.3" in the 1978 book, and the [Wikipedia article on IFIP Working Group 2.3](https://en.wikipedia.org/wiki/IFIP_Working_Group_2.3).
+For more on the history of WG2.3, see Mike Woodger's essay "A History of IFIP WG2.3" in the 1978 book [[1]](#ref1), and the [Wikipedia article on IFIP Working Group 2.3](https://en.wikipedia.org/wiki/IFIP_Working_Group_2.3).
+
+---
+
+<a id="ref1"></a> **[1]** David Gries (ed.), [*Programming Methodology: A Collection of Articles by Members of IFIP WG2.3*](https://link.springer.com/book/10.1007/978-1-4612-6315-9), Springer-Verlag, 1978.

--- a/pages/history.md
+++ b/pages/history.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: History
-nav_order: 4
+nav_order: 3
 ---
 
 In December 1968, IFIP Working Group 2.1 adopted Aad van Wijngaarden's proposal as a successor to Algol 60, ultimately leading to ALGOL 68. A group of WG2.1 members opposed the proposal and produced a minority report. They also felt that rather than just programming languages, a forum was needed to discuss the general problem of programming. Another impetus was the findings of the first of the NATO Software Engineering Conferences, held in 1968, which spoke of the "software crisis" then seen as gripping the computing world.

--- a/pages/history.md
+++ b/pages/history.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: History
+nav_order: 4
+---
+
+In December 1968, IFIP Working Group 2.1 adopted Aad van Wijngaarden's proposal as a successor to Algol 60, ultimately leading to ALGOL 68. A group of WG2.1 members opposed the proposal and produced a minority report. They also felt that rather than just programming languages, a forum was needed to discuss the general problem of programming. Another impetus was the findings of the first of the NATO Software Engineering Conferences, held in 1968, which spoke of the "software crisis" then seen as gripping the computing world.
+
+IFIP's parent committee TC2 approved the formation of a new Working Group, WG2.3, for this purpose. Mike Woodger agreed to chair it, and Brian Randell suggested the title "Programming Methodology."
+
+An organizing meeting was held in Oslo, 20–22 July 1969, with the following attending: Ole-Johan Dahl, Edsger W. Dijkstra, Douglas McIlroy, Brian Randell, Gerhard Seegmueller, Wlad Turski, Mike Woodger, and Manfred Paul (chair of WG2.1). Doug Ross was also a founding member.
+
+The first formal meeting was held in Copenhagen, Denmark in March 1970. It was attended by Ole-Johan Dahl, Edsger W. Dijkstra, Per Brinch Hansen, Tony Hoare, M. M. Lehman, J. Madey, Doug McIlroy, George Radin, Brian Randell, John Reynolds, Doug Ross, Christopher Strachey, and Warren Teitelman.
+
+The founding members were predominantly academic, and a deliberate attempt was made to bring in members from industry and commerce as well as from Asia and the USSR. WG2.3 generally meets once or twice a year for five days at a time. Until 1976, all meetings were held in Europe, but after that meetings often alternated between Europe and North America. Several meetings have been held in Australia.
+
+In its initial years, WG2.3 did not produce reports of any kind of its meetings. Meetings centered on the presentation and discussion of research underway, which meant that members could receive their colleagues' constructive criticism at a much earlier stage than usual. As such, WG2.3 became a productive assembly at which researchers such as Dijkstra could work out many of the ideas that they subsequently brought forth in published papers.
+
+In the late 1970s, it was felt that WG2.3 should make more public the nature of its work and what had been accomplished. Accordingly, the book *Programming Methodology: A Collection of Articles by Members of IFIP WG2.3* (edited by David Gries, Springer-Verlag, 1978) was published. In 2003, a second book *Programming Methodology* (edited by Annabelle McIver and Carroll Morgan, Springer-Verlag) was published, containing both new material and reviews of areas and problems for further investigation.
+
+For more on the history of WG2.3, see Mike Woodger's essay "A History of IFIP WG2.3" in the 1978 book, and the [Wikipedia article on IFIP Working Group 2.3](https://en.wikipedia.org/wiki/IFIP_Working_Group_2.3).

--- a/pages/meetings/index.md
+++ b/pages/meetings/index.md
@@ -4,7 +4,7 @@ title: Meetings
 permalink: /meetings/
 has_children: true
 has_toc: false
-nav_order: 3
+nav_order: 4
 ---
 {%- assign all_pages = site.pages -%}
 {%- assign meetings = all_pages | where: "grand_parent", "Meetings" | sort: "nav_order" -%}


### PR DESCRIPTION
## Summary
- Add a dedicated History page (based on the Wikipedia article on IFIP WG 2.3) with its own navigation sidebar entry
- Place History between Members and Meetings in the nav order
- Add a citation [1] for the 1978 *Programming Methodology* book with a link to the Springer page

## Test plan
- [ ] Verify the History page renders correctly and appears in the sidebar between Members and Meetings
- [ ] Verify the [1] citation links scroll to the reference at the bottom of the page
- [ ] Verify the Springer link in the reference works